### PR TITLE
arping: export findIPInNetworkFromInterface

### DIFF
--- a/arping.go
+++ b/arping.go
@@ -60,12 +60,12 @@ package arping
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net"
 	"os"
 	"time"
-	"fmt"
 )
 
 var (
@@ -109,7 +109,7 @@ func PingOverIface(dstIP net.IP, iface net.Interface) (net.HardwareAddr, time.Du
 	}
 
 	srcMac := iface.HardwareAddr
-	srcIP, err := findIPInNetworkFromIface(dstIP, iface)
+	srcIP, err := FindIPInNetworkFromIface(dstIP, iface)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/netutils.go
+++ b/netutils.go
@@ -6,7 +6,7 @@ import (
 	"net"
 )
 
-func findIPInNetworkFromIface(dstIP net.IP, iface net.Interface) (net.IP, error) {
+func FindIPInNetworkFromIface(dstIP net.IP, iface net.Interface) (net.IP, error) {
 	addrs, err := iface.Addrs()
 
 	if err != nil {
@@ -35,7 +35,7 @@ func findUsableInterfaceForNetwork(dstIP net.IP) (*net.Interface, error) {
 	}
 
 	hasAddressInNetwork := func(iface net.Interface) bool {
-		if _, err := findIPInNetworkFromIface(dstIP, iface); err != nil {
+		if _, err := FindIPInNetworkFromIface(dstIP, iface); err != nil {
 			return false
 		}
 		return true


### PR DESCRIPTION
This will be used in cilium encryption paths.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>