### PR TITLE
arping_linux: Use syscall.Select() to unblock Recvmsg()

### DIFF
--- a/arping.go
+++ b/arping.go
@@ -72,6 +72,7 @@ import (
 var (
 	// ErrTimeout error
 	ErrTimeout = errors.New("timeout")
+	ErrSize = errors.New("truncated")
 
 	verboseLog = log.New(ioutil.Discard, "", 0)
 	timeout    = 1 * time.Second
@@ -147,7 +148,7 @@ func PingOverIface(dstIP net.IP, iface net.Interface) (net.HardwareAddr, time.Du
 		}
 		for {
 			// receive arp response
-			response, receiveTime, err := req.receive()
+			response, receiveTime, err := req.receive(timeout)
 
 			if err != nil {
 				select {


### PR DESCRIPTION
Linux Recvmsg() does not unblock when the socket is closed. TCP
sockets could be unblocked with syscall.Shutdown(), but apparently
that does not work for raw sockets, as it always returned error
"operation not supported". Use syscall.Select() to not block on
Recvmsg and return after timeout.

Before this change the exiting unit test failed, after this it succeeds.

Ref. https://stackoverflow.com/questions/6389970/unblock-recvfrom-when-socket-is-closed

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>