### PR TITLE
arping: Fix response correlation to make lib thread-safe

### DIFF
--- a/arp_datagram.go
+++ b/arp_datagram.go
@@ -73,7 +73,8 @@ func (datagram arpDatagram) SenderMac() net.HardwareAddr {
 }
 
 func (datagram arpDatagram) IsResponseOf(request arpDatagram) bool {
-	return datagram.oper == responseOper && bytes.Compare(request.spa, datagram.tpa) == 0
+	return datagram.oper == responseOper && bytes.Equal(request.spa, datagram.tpa) &&
+		bytes.Equal(request.tpa, datagram.spa)
 }
 
 func parseArpDatagram(buffer []byte) arpDatagram {


### PR DESCRIPTION
The arping library sends an ARP(-ping) request via a raw socket with
proto set to ARP. This means that it can receive via the socket any ARP
packet.

To filter out a response, the library was checking whether a received
packet was ARP response AND whether response dst IP was equal to request
src IP. Obviously, the latter check was not working properly when the
same sender (src IP) was issuing multiple concurrent arpings.

To fix this, extend the filtering by checking whether request dst IP is
the same as response src IP.

Reported-by: Andrey Voronkov
Signed-off-by: Martynas Pumputis <m@lambda.lt>